### PR TITLE
v0.2.1 - Applications route work; setup config route and add initial form editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackathon-internal",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "hackathon-internal: a web app for hackathon internal tools",
   "author": "Jack Ketcham <jack@jackketcham.com> (http://jackketcham.com)",
   "license": "MIT",

--- a/src/js/apis/application.api.js
+++ b/src/js/apis/application.api.js
@@ -136,6 +136,55 @@ var ApplicationAPI = {
         return APIUtil.handleError(err, res, cb);
       }
     });
+  },
+
+  getApplicationConfigs: function getApplicationConfigs(options, cb) {
+    options = options || {};
+
+    var query = APIUtil.query(options, true);
+
+    xhr({
+      uri: 'http://localhost:3000/applications/configs?' + query,
+      method: 'GET',
+      headers: {
+        'Authorization': 'Bearer ' + APIUtil.getToken()
+      }
+    }, function response(err, res, body) {
+      if (!err && res.statusCode === 200) {
+        var parsedBody = JSON.parse(body);
+
+        return cb(null, parsedBody);
+      } else {
+        APIUtil.badResponse(res, function() {
+        });
+        return APIUtil.handleError(err, res, cb);
+      }
+    });
+  },
+
+  updateApplicationConfig: function updateApplicationConfig(application, cb) {
+    if (!application) {
+      cb('application required', null);
+    }
+
+    xhr({
+      uri: 'http://localhost:3000/applications/configs/' + application._id,
+      method: 'PUT',
+      headers: {
+        'Authorization': 'Bearer ' + APIUtil.getToken()
+      },
+      body: JSON.stringify(application)
+    }, function response(err, res, body) {
+      if (!err && res.statusCode === 200) {
+        var parsedBody = JSON.parse(body);
+
+        return cb(null, parsedBody);
+      } else {
+        APIUtil.badResponse(res, function() {
+        });
+        return APIUtil.handleError(err, res, cb);
+      }
+    });
   }
 
 };

--- a/src/js/components/application-index.js
+++ b/src/js/components/application-index.js
@@ -7,12 +7,19 @@ var Router = require('react-router');
 // Flux
 var ApplicationActions = require('../actions/application.actions');
 var ApplicationStore = require('../stores/application.store');
+var SessionStore = require('../stores/session.store');
 
 // Components
 var ApplicationTable = require('./application-table');
 
 function _getApplications() {
   return ApplicationStore.getApplications();
+}
+
+function _getCurrentHackathon() {
+  var hackathon = SessionStore.getCurrentHackathon();
+
+  return hackathon;
 }
 
 var ApplicationIndex = React.createClass({
@@ -31,6 +38,12 @@ var ApplicationIndex = React.createClass({
   },
 
   componentWillMount: function componentWillMount() {
+    var hackathon = _getCurrentHackathon();
+
+    this.setState({
+      currentHackathon: hackathon
+    });
+
     this._filterRowsBy(this.state.filterBy);
   },
 
@@ -41,13 +54,6 @@ var ApplicationIndex = React.createClass({
 
   componentWillUnmount: function componentWillUnmount() {
     ApplicationStore.removeChangeListener(this._onChange);
-  },
-
-  _onChange: function _onChange() {
-    this.setState({
-      applications: _getApplications()
-    });
-    this._filterRowsBy(this.state.filterBy);
   },
 
   _onClick: function _onClick(event) {
@@ -78,24 +84,28 @@ var ApplicationIndex = React.createClass({
     });
   },
 
+  _onChange: function _onChange() {
+    var hackathon = _getCurrentHackathon();
+
+    this.setState({
+      applications: _getApplications(),
+      currentHackathon: hackathon
+    });
+
+    this._filterRowsBy(this.state.filterBy);
+  },
+
   render: function render() {
     return (
-      h('div', {className: 'container'}, [
-        h('div', {className: 'row'}, [
-          h('section', {className: 'col-md-12'}, [
-            h('div', {className: 'page__header'}, [
-              h('h4', {className: 'page__title'}, 'Application index')
-            ])
-          ]),
-          h('section', {className: 'col-md-12'}, [
-            h('div', {className: 'page__body'}, [
-              h(ApplicationTable, {
-                applications: this.state.sortedApplications,
-                initialLength: this.state.applications.length,
-                filter: '',
-                onClick: this._onClick
-              })
-            ])
+      h('div', {className: 'row'}, [
+        h('section', {className: 'col-md-12'}, [
+          h('div', {className: 'page__body'}, [
+            h(ApplicationTable, {
+              applications: this.state.sortedApplications,
+              initialLength: this.state.applications.length,
+              filter: '',
+              onClick: this._onClick
+            })
           ])
         ])
       ])

--- a/src/js/components/handlers/application-config.js
+++ b/src/js/components/handlers/application-config.js
@@ -1,0 +1,119 @@
+'use strict';
+
+var h = require('react-hyperscript');
+var moment = require('moment');
+var React = require('react');
+var Router = require('react-router');
+
+var ApplicationAPI = require('../../apis/application.api');
+
+/**
+ * Application config page. User can edit
+ * attributes of an application.
+ */
+var ApplicationConfig = React.createClass({
+
+  displayName: 'ApplicationConfig',
+
+  mixins: [Router.Navigation, Router.State],
+
+  getInitialState: function getInitialState() {
+    return {
+      configs: []
+    };
+  },
+
+  componentDidMount: function componentDidMount() {
+    var self = this;
+    var isActiveRoute = this.isActive('applications-config-page', this.props.params, this.props.query);
+    var options = {};
+
+    if (!isActiveRoute) {
+      ApplicationAPI.getApplicationConfigs(options, function setConfigs(err, configs) {
+        if (err) {
+          // TODO: handle err
+        }
+        self.setState({
+          configs: configs
+        });
+      });
+    }
+  },
+
+  _onSelection: function _onSelection(event) {
+    var target = event.target;
+
+    if (target.id) {
+      this.transitionTo('application-config-page', {id: target.id});
+    }
+  },
+
+  _getConfigs: function _getConfigs() {
+    var self = this;
+    var configs = this.state.configs;
+
+    var configPanels = configs.map(function(config) {
+      return h('div', {className: 'col-md-6'}, [
+        h('div', {className: 'panel panel-default'}, [
+          h('div', {className: 'panel-heading'}, [
+            h('h3', {className: 'panel-title _panel-title'}, 'Role: '),
+            h('span', config.role),
+            h('button', {
+              className: 'btn btn-link pull-right',
+              onClick: self._onSelection,
+              id: config._id
+            }, 'Edit')
+          ]),
+          h('div', {className: 'panel-body'}, [
+            h('ul', {className: 'list-unstyled'}, [
+              h('li', [
+                h('strong', 'Open: '),
+                h('span', moment(config.open_at).format('lll'))
+              ]),
+              h('li', [
+                h('strong', 'Close: '),
+                h('span', moment(config.close_at).format('lll'))
+              ]),
+              h('li', [
+                h('strong', 'Decision: '),
+                h('span', moment(config.decision_at).format('lll'))
+              ])
+            ])
+          ])
+        ])
+      ]);
+    });
+
+    return h('div', [
+      configPanels
+    ]);
+  },
+
+  _getConfigConent: function _getConfigConent() {
+    var isActiveRoute = this.isActive('application-config-page', this.props.params, this.props.query);
+    var content;
+
+    if (!isActiveRoute) {
+      content = this._getConfigs();
+    } else {
+      content = h(Router.RouteHandler);
+    }
+
+    return content;
+  },
+
+  render: function render() {
+    var content = this._getConfigConent();
+
+    return (
+      h('div', {className: 'row'}, [
+        h('div', {className: 'col-md-12'}, [
+          content
+        ])
+      ])
+    );
+  }
+
+});
+
+module.exports = ApplicationConfig;

--- a/src/js/components/handlers/application-config.module.js
+++ b/src/js/components/handlers/application-config.module.js
@@ -1,0 +1,186 @@
+'use strict';
+
+var h = require('react-hyperscript');
+var moment = require('moment');
+var React = require('react');
+var Router = require('react-router');
+
+var ApplicationAPI = require('../../apis/application.api');
+
+function buildForm(application) {
+  var form = {};
+
+  if (!application) {
+    return;
+  }
+
+  form._id = application._id;
+  form.open_at = application.open_at.split('.')[0];
+  form.close_at = application.close_at.split('.')[0];
+  form.decision_at = application.decision_at.split('.')[0];
+
+  return form;
+}
+
+/**
+ * Application config page. User can edit
+ * attributes of an application.
+ */
+var ApplicationConfig = React.createClass({
+
+  displayName: 'ApplicationConfig',
+
+  mixins: [Router.Navigation, Router.State],
+
+  getInitialState: function getInitialState() {
+    return {
+      applicationConfig: {},
+      configs: [],
+      form: {}
+    };
+  },
+
+  componentDidMount: function componentDidMount() {
+    var self = this;
+    var params = this.getParams();
+    var options = {};
+
+    if (params.id) {
+      options.id = params.id;
+    }
+
+    ApplicationAPI.getApplicationConfigs(options, function(err, applications) {
+      if (err) {
+
+      }
+
+      self.setState({
+        form: buildForm(applications[0]),
+        applicationConfig: applications[0]
+      });
+    });
+  },
+
+  _onFormChange: function _onFormChange(event) {
+    var target = event.target;
+    var application = this.state.form;
+
+    application[target.id] = target.value;
+
+    this.setState({
+      form: application
+    });
+  },
+
+  _onFormSubmission: function _onFormSubmission(event) {
+    var self = this;
+    var request = this.state.form;
+
+    ApplicationAPI.updateApplicationConfig(request, function onUpdate(err, application) {
+      if (err) {
+
+      }
+
+      self.setState({
+        applicationConfig: application,
+        form: buildForm(application)
+      });
+    });
+
+    event.preventDefault();
+  },
+
+  _getContent: function _getContent() {
+    var isActiveRoute = this.isActive('form-editor', this.props.params, this.props.query);
+    var form = this.state.form;
+    var content;
+
+    if (isActiveRoute) {
+      content = h(Router.RouteHandler);
+    } else {
+      content = h('div', {className: 'row'}, [
+        h('div', {className: 'col-md-4'}, [
+          h('form', [
+            h('div', {className: 'form-group'}, [
+              h('label', {htmlFor: 'open_at'}, 'Open application submission at:'),
+              h('input', {type: 'datetime-local', className: 'form-control', id: 'open_at', value: form.open_at, onChange: this._onFormChange})
+            ]),
+            h('div', {className: 'form-group'}, [
+              h('label', {htmlFor: 'close_at'}, 'Close application submission at:'),
+              h('input', {type: 'datetime-local', className: 'form-control', id: 'close_at', value: form.close_at, onChange: this._onFormChange})
+            ]),
+            h('div', {className: 'form-group'}, [
+              h('label', {htmlFor: 'decision_at'}, 'Send application decision emails at:'),
+              h('input', {type: 'datetime-local', className: 'form-control', id: 'decision_at', value: form.decision_at, onChange: this._onFormChange})
+            ]),
+            h('div', {className: 'form-group'}, [
+              h('button', {
+                className: 'btn btn-success',
+                onClick: this._onFormSubmission
+              }, 'Update')
+            ])
+          ])
+        ]),
+        h('div', {className: 'col-md-8 text-center'}, [
+          h('h5', 'Eventual application preview here')
+        ])
+      ]);
+    }
+
+    return content;
+  },
+
+  _getNav: function _getNav() {
+    var self = this;
+    var isActiveRoute = this.isActive('form-editor', this.props.params, this.props.query);
+    var nav;
+
+    nav = h('ul', {className: 'nav nav-pills'}, [
+      h('li', {
+        role: 'presentation',
+      }, [
+        h('a', {
+          href: '',
+          onClick: function goBack() {
+            self.goBack();
+          }
+        }, [
+          h('span', {className: 'glyphicon _glyphicon glyphicon-chevron-left'}),
+          h('span', 'Back')
+        ])
+      ]),
+      h('li', {
+        role: 'presentation',
+        className: isActiveRoute ? 'pull-right active' : 'pull-right'
+      }, [
+        h(Router.Link, {to: 'form-editor', params: this.getParams()}, [
+          h('span', {className: 'glyphicon _glyphicon glyphicon-edit'}),
+          h('span', 'Edit form')
+        ])
+      ])
+    ]);
+
+    return nav;
+  },
+
+  render: function render() {
+    var applicationConfig = this.state.applicationConfig;
+    var content = this._getContent();
+    var nav = this._getNav();
+
+    return (
+      h('div', {className: 'row'}, [
+        h('div', {className: 'col-md-12'}, [
+          h('h3', 'Application role: ' + applicationConfig.role),
+          nav
+        ]),
+        h('div', {className: 'col-md-12'}, [
+          content
+        ])
+      ])
+    );
+  }
+
+});
+
+module.exports = ApplicationConfig;

--- a/src/js/components/handlers/application-handler.js
+++ b/src/js/components/handlers/application-handler.js
@@ -4,12 +4,137 @@ var h = require('react-hyperscript');
 var React = require('react');
 var Router = require('react-router');
 
+// Flux
+var ApplicationStore = require('../../stores/application.store');
+var SessionStore = require('../../stores/session.store');
+
+function _getCurrentHackathon() {
+  var hackathon = SessionStore.getCurrentHackathon();
+
+  return hackathon;
+}
+
 var ApplicationHandler = React.createClass({
 
+  displayName: 'ApplicationHandler',
+
+  mixins: [Router.State, Router.Navigation],
+
+  getInitialState: function getInitialState() {
+    return {
+      tabs: []
+    };
+  },
+
+  componentWillMount: function componentWillMount() {
+    var hackathon = _getCurrentHackathon();
+    var tabs = this._setTabs(hackathon);
+
+    this.setState({
+      currentHackathon: _getCurrentHackathon(),
+      tabs: tabs
+    });
+  },
+
+  componentDidMount: function componentDidMount() {
+    ApplicationStore.addChangeListener(this._onChange);
+  },
+
+  componentWillUnmount: function componentWillUnmount() {
+    ApplicationStore.removeChangeListener(this._onChange);
+  },
+
+  _onChange: function _onChange() {
+    var hackathon = _getCurrentHackathon();
+    var tabs = this._setTabs(hackathon);
+
+    this.setState({
+      currentHackathon: hackathon,
+      tabs: tabs
+    });
+  },
+
+  _onSelection: function _onSelection(event) {
+    var target = event.target;
+
+    this.transitionTo(target.getAttribute('data-tab'));
+  },
+
+  _setTabs: function _setTabs(hackathon) {
+    var isActiveRoute = this.isActive('applications-index', this.props.params, this.props.query);
+    var baseIconClass = 'glyphicon _glyphicon';
+    var tabs = [{
+      name: 'Index',
+      iconClass: baseIconClass + ' glyphicon-list',
+      routeName: 'applications-index'
+    }];
+    var hackathonTabs = [{
+      name: 'Config',
+      iconClass: baseIconClass + ' glyphicon-cog',
+      routeName: 'applications-config'
+    }];
+
+    if (hackathon) {
+      Array.prototype.push.apply(tabs, hackathonTabs);
+    } else if (!isActiveRoute) {
+      this.transitionTo('applications-index');
+    }
+
+    return tabs;
+  },
+
+  _getNavTabs: function _getNavTabs() {
+    var self = this;
+
+    var tabs = this.state.tabs.map(function(tab, index) {
+      var isActiveRoute = self.isActive(tab.routeName, self.props.params, self.props.query);
+
+      return h('li', {
+        className: isActiveRoute ? 'active' : '',
+        role: 'presentation',
+        key: index
+      }, [
+        h('a', {
+          className: 'hi-sudo-link',
+          'aria-controls': tab.name.toLowerCase(),
+          'data-toggle': 'tab',
+          'data-tab': tab.routeName,
+          role: 'tab',
+          onClick: self._onSelection,
+        }, [
+          h('span', {className: tab.iconClass}),
+          h('span', tab.name)
+        ])
+      ]);
+    });
+
+    return h('ul', {className: 'nav nav-tabs', role: 'tablist'}, [
+      tabs
+    ]);
+  },
+
   render: function render() {
+    var tabs = this._getNavTabs();
+
     return (
-      h('div', [
-        h(Router.RouteHandler)
+      h('div', {className: 'container'}, [
+        h('div', {className: 'row'}, [
+          h('section', {className: 'col-md-12'}, [
+            h('div', {className: 'page__header'}, [
+              h('h2', {className: 'page__title title--inline'}, this.state.currentHackathon.season || 'All seasons'),
+              h('h4', {className: 'page__title title--inline text-muted'}, '/'),
+              h('h4', {className: 'title--inline'}, 'Applications')
+            ])
+          ]),
+          h('section', {className: 'col-md-12'}, [
+            h('div', {className: 'page__body'}, [
+              tabs,
+              h('div', {className: 'tab__content'}, [
+                h(Router.RouteHandler)
+              ])
+            ])
+          ])
+        ])
       ])
     );
   }

--- a/src/js/components/handlers/application-page.js
+++ b/src/js/components/handlers/application-page.js
@@ -36,8 +36,6 @@ var ApplicationPage = React.createClass({
     var self = this;
     params = params || self.props.params;
 
-    console.log(params);
-
     ApplicationAPI.getAdjacentApplications(params, function(err, res) {
       if (!err && res) {
         self.setState({
@@ -72,10 +70,7 @@ var ApplicationPage = React.createClass({
         var prevLink;
         var nextLink;
 
-        console.log('current: %s', application._id);
-
         if (prevApplication) {
-          console.log('prev: %s', prevApplication._id);
           prevLink = h('div', {className: 'pull-left'}, [
             h('span', {className: 'glyphicon glyphicon-chevron-left'}),
             h(Router.Link, {
@@ -86,7 +81,6 @@ var ApplicationPage = React.createClass({
           ]);
         }
         if (nextApplication) {
-          console.log('next: %s', nextApplication._id);
           nextLink = h('div', {className: 'pull-right'}, [
             h(Router.Link, {
               to: 'applicationPage',

--- a/src/js/components/handlers/form-editor.js
+++ b/src/js/components/handlers/form-editor.js
@@ -1,0 +1,297 @@
+'use strict';
+
+var classnames = require('classnames');
+var h = require('react-hyperscript');
+var React = require('react');
+
+var ApplicationAPI = require('../../apis/application.api');
+
+var MODULE_TYPES = {
+  SHORT_TEXT: 'short_text',
+  LONG_TEXT: 'long_text',
+  MULTIPLE_CHOICE: 'multiple_choice',
+  DROPDOWN: 'dropdown'
+};
+
+var LongTextModule = React.createClass({
+
+  render: function render() {
+    return (
+      h('span', 'LongTextModule')
+    );
+  }
+
+});
+
+var MultipleChoiceModule = React.createClass({
+
+  render: function render() {
+    return (
+      h('span', 'MultipleChoiceModule')
+    );
+  }
+
+});
+
+var DropdownModule = React.createClass({
+
+  render: function render() {
+    return (
+      h('span', 'DropdownModule')
+    );
+  }
+
+});
+
+var ShortTextModule = React.createClass({
+
+  displayName: 'ShortTextModule',
+
+  getInitialState: function getInitialState() {
+    return {
+      name: '',
+    };
+  },
+
+  handleFormChange: function handleFormChange(event) {
+    var target = event.target;
+  },
+
+  render: function render() {
+    console.log('%s render!', 'ShortTextModule');
+
+    return (
+      h('div', [
+        h('form', [
+          h('div', {className: 'form-group'}, [
+            h('label', {htmlFor: 'name'}, 'Module name'),
+            h('input', {type: 'text', className: 'form-control', id: 'name', onChange: this.handleFormChange})
+          ]),
+          h('div', {className: 'form-group'}, [
+            h('label', {htmlFor: 'question'}, 'Question'),
+            h('input', {type: 'text', className: 'form-control', id: 'question', onChange: this.handleFormChange})
+          ]),
+          h('div', {className: 'form-group'}, [
+            h('label', {htmlFor: 'max_length'}, 'Max length'),
+            h('input', {type: 'text', className: 'form-control', id: 'max_length', onChange: this.handleModuleCreation})
+          ]),
+          h('div', {className: 'form-group'}, [
+            h('div', {className: 'checkbox'}, [
+              h('label', [
+                h('input', {type: 'checkbox'}),
+                'Required'
+              ])
+            ])
+          ])
+        ])
+      ])
+    );
+  }
+
+});
+
+// thing you use to arrange/high level config on form modules
+// drag n drop
+var ModuleContainer = React.createClass({
+
+  displayName: 'ModuleContainer',
+
+  propTypes: {
+    modules: []
+  },
+
+  getInitialState: function getInitialState() {
+    return {};
+  },
+
+  render: function render() {
+    console.log('%s render!', 'ModuleContainer');
+
+    var Modules = this.props.modules.map(function(module) {
+      return h('div', {className: 'module__box'}, [
+        h('p', module.name),
+        h('p', module.question),
+        h('button', 'Wow')
+      ]);
+    });
+
+    return (
+      h('div', {className: 'row'}, [
+        h('div', {className: 'col-md-12'}, [
+          h('span', 'Module container'),
+          Modules
+        ])
+      ])
+    );
+  }
+
+});
+
+// thing you use to create a module
+// select from list of predefined types
+//    short text, long text, dropdown, etc.
+var ModuleCreator = React.createClass({
+
+  displayName: 'ModuleCreator',
+
+  getInitialState: function getInitialState() {
+    return {
+      type: ''
+    };
+  },
+
+  propTypes: {
+    // on module completion
+    onCreation: React.PropTypes.func
+  },
+
+  componentDidMount: function componentDidMount() {
+
+  },
+
+  handleCreation: function handleCreation(event) {
+    var target = event.target;
+
+    console.log(target);
+
+    this.props.onCreation({name: target.id});
+  },
+
+  handleSelection: function handleSelection(event) {
+    var target = event.target;
+
+    console.log(target);
+
+    this.setState({
+      type: target.id
+    });
+
+    console.log(this.state);
+  },
+
+  render: function render() {
+    console.log('%s render!', 'ModuleCreator');
+    var editor;
+
+    switch (this.state.type) {
+      case MODULE_TYPES.SHORT_TEXT:
+        editor = h(ShortTextModule);
+        break;
+
+      case MODULE_TYPES.LONG_TEXT:
+        editor = h(LongTextModule);
+        break;
+
+      case MODULE_TYPES.MULTIPLE_CHOICE:
+        editor = h(MultipleChoiceModule);
+        break;
+
+      case MODULE_TYPES.DROPDOWN:
+        editor = h(DropdownModule);
+        break;
+
+      default:
+        editor = h('div', {className: 'text-center'}, [
+          h('h5', 'Select a module type on the right!')
+        ]);
+        break;
+    }
+
+    return (
+      h('div', {className: 'module__container'}, [
+        h('div', {className: 'row'}, [
+          h('div', {className: 'col-md-4'}, [
+            h('ul', {className: 'list-unstyled'}, [
+              h('li', {className: ''}, [
+                h('span', {className: 'hi-sudo-link', onClick: this.handleSelection, id: 'short_text'}, 'Short text')
+              ]),
+              h('li', {className: ''}, [
+                h('span', {className: 'hi-sudo-link', onClick: this.handleSelection, id: 'long_text'}, 'Long text')
+              ]),
+              h('li', {className: ''}, [
+                h('span', {className: 'hi-sudo-link', onClick: this.handleSelection, id: 'multiple_choice'}, 'Multiple choice')
+              ]),
+              h('li', {className: ''}, [
+                h('span', {className: 'hi-sudo-link', onClick: this.handleSelection, id: 'dropdown'}, 'Dropdown')
+              ])
+            ])
+          ]),
+          h('div', {className: 'col-md-8'}, [
+            editor,
+            h('div', [
+              h('ul', {className: 'list-inline'}, [
+                h('li', [
+                  h('button', {className: 'btn btn-primary', onClick: this.handleCreation}, 'Add module')
+                ])
+              ])
+            ])
+          ])
+        ])
+      ])
+    );
+  }
+
+});
+
+/**
+ * Application form creator.
+ */
+var FormEditor = React.createClass({
+
+  displayName: 'FormEditor',
+
+  getInitialState: function getInitialState() {
+    return {
+      modules: []
+    };
+  },
+
+  componentWillMount: function componentWillMount() {
+
+  },
+
+  componentDidMount: function componentDidMount() {
+
+  },
+
+  handleModuleCreation: function handleModuleCreation(module) {
+    var modules = this.state.modules;
+
+    modules.push(module);
+
+    this.setState({
+      modules: modules
+    });
+  },
+
+  render: function render() {
+    console.log('%s render!', 'formEditor');
+
+    return(
+      h('div', {className: 'container'}, [
+        h('div', {className: 'row'}, [
+          h('div', {className: 'col-md-12'}, [
+            h(ModuleCreator, {
+              onCreation: this.handleModuleCreation
+            })
+          ])
+        ]),
+        h('div', {className: 'row'}, [
+          h('div', {className: 'col-md-12'}, [
+            h(ModuleContainer, {
+              modules: this.state.modules
+            })
+          ])
+        ]),
+        h('div', {className: 'row'}, [
+          h('div', {className: 'col-md-12'}, [
+
+          ])
+        ])
+      ])
+    );
+  }
+
+});
+
+module.exports = FormEditor;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,7 +6,7 @@ var h = require('react-hyperscript');
 
 var App = require('./components/handlers/app');
 var ApplicationConfig = require('./components/handlers/application-config');
-var ApplicationConfigModule = require('./components/application-config.module');
+var ApplicationConfigModule = require('./components/handlers/application-config.module');
 var ApplicationEditor = require('./components/handlers/application-editor');
 var ApplicationHandler = require('./components/handlers/application-handler');
 var ApplicationIndex = require('./components/application-index');

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -32,6 +32,26 @@
   cursor: pointer;
 }
 
+// Overwrite bootstrap stuff
+._tab-panel {
+  padding: 15px;
+}
+
+._glyphicon {
+  margin-right: 5px;
+}
+
+._panel-title {
+  display: inline-block;
+  margin-right: 5px;
+}
+
+.panel-heading {
+  button {
+    margin-top: -5px;
+  }
+}
+
 /**
  * Global/General
  */
@@ -56,6 +76,7 @@ li.task {
   }
 }
 
+
 /**
  * Typography
  */
@@ -64,6 +85,11 @@ li.task {
   text-decoration: none;
   cursor: pointer;
 }
+
+.title--inline {
+  display: inline-block;
+}
+
 
 /**
  * Modules
@@ -75,10 +101,32 @@ li.task {
   }
 }
 
+
 /**
  * (Fixed Data) Table
  */
 
 .hi-table__row {
   border-bottom: 1px solid #d3d3d3;
+}
+
+
+/**
+ * Page
+ */
+
+.page__title {
+  margin-right: 5px;
+}
+
+
+/**
+ * Tabs
+ */
+
+.tab__content {
+  padding: 15px;
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
 }


### PR DESCRIPTION
Here's what v0.2.1 is looking like:

![hackathon-internal-v0 2 1](https://cloud.githubusercontent.com/assets/1548556/9028010/2aa183bc-391f-11e5-9271-f3ee1456529e.gif)
Added application configuration routes.  Notice you have to set a specific hackathon season from the navbar dropdown in order to access application configs for that hackathon. Currently the application config page just has inputs to edit open/close/decision dates (reloaded the page in the gif to show backend saving it correctly).
Also added a prototype for the form editor that is a child route to the application config page.
